### PR TITLE
Correct timezone use

### DIFF
--- a/ChoPGP/ChoPGPEncryptDecrypt.cs
+++ b/ChoPGP/ChoPGPEncryptDecrypt.cs
@@ -834,7 +834,7 @@ namespace Cinchoo.PGP
                 (PublicKeyAlgorithmTag)(int)PublicKeyAlgorithm,
                 publicKey,
                 privateKey,
-                DateTime.Now,
+                DateTime.UtcNow,
                 identity,
                 (SymmetricKeyAlgorithmTag)(int)SymmetricKeyAlgorithm,
                 passPhrase,


### PR DESCRIPTION
Keys must be signed with the same timezone they're generated with, in this case UTC.

Fixes #10.